### PR TITLE
Use rollup-plugin-hypothetical behind the scenes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ node_js:
   - "4.1"
   - "4.0"
   - "0.12"
-  - "0.11"
-  - "0.10"
 before_script:
   - npm install

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Import contents from Vinyl files in Rollup.",
   "main": "src/index.js",
   "engines" : {
-    "node" : ">=0.10"
+    "node" : ">=0.12"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "ava": "^0.15.2",
     "vinyl": "^1.1.1"
+  },
+  "dependencies": {
+    "rollup-plugin-hypothetical": "^1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var path = require('path');
+var hypothetical = require('rollup-plugin-hypothetical');
 
 
 /**
@@ -14,60 +14,22 @@ function RollupPluginVinyl(files) {
 
 
   /** @type {Object} */
-  var pathes = {};
+  var wonderland = {};
 
   files.forEach(function(file) {
-    pathes[RollupPluginVinyl.unix(file.path)] = file;
-  }, this);
-
-
-  return {
-
-    files: Array.isArray(files) ? files : [files],
-
-    /**
-     * @param {string} importee Import's id.
-     * @param {string} importer Tmporter's id.
-     * @return {string|null|undefined|false} id The resolved id.
-     */
-    resolveId: function (importee, importer) {
-
-      var id = null;
-
-      if (pathes[importee]) {
-        id = importee;
-      } else {
-        id = RollupPluginVinyl.unix(path.resolve(
-          path.dirname(importer),
-          importee
-        ));
-      }
-
-      return id;
-    },
-
-    /**
-     * @param {string} id The id to load.
-     * @return {string} The file content
-     */
-    load: function (id) {
-      return pathes[id] ? pathes[id].contents.toString() : null;
+    if (!file.isBuffer()) {
+      throw Error('Content of file "' + file.path + '" is not a buffer.');
     }
+    wonderland[file.path] = file.contents.toString();
+  });
 
-  };
+
+  return hypothetical({
+    files: wonderland,
+    allowRealFiles: true
+  });
 
 }
-
-
-/**
- * Transform native path to Unix path style
- *
- * @param {string} value A path.
- * @return {string} a unix style path;
- */
-RollupPluginVinyl.unix = function unix(value, sep) {
-  return value.split(sep || path.sep).join('/');
-};
 
 
 module.exports = RollupPluginVinyl;

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ test('Accept Vinyl as parameter, resolve his id and load his contents.', t => {
     contents: new Buffer('fake')
   });
 
-  var unixPath = Plugin.unix(file.path);
+  var unixPath = unix(file.path);
 
   var plugin = Plugin(file);
   var id = plugin.resolveId(unixPath);
@@ -29,14 +29,14 @@ test('Accept array as parameters, resolve ids, load contents and resolve relativ
     path: path.resolve('src/fake.js'),
     contents: new Buffer('fake1')
   });
-  var unixPath1 = Plugin.unix(fake1.path);
+  var unixPath1 = unix(fake1.path);
 
   var fake2 = new Vinyl({
     base: path.resolve('src'),
     path: path.resolve('src/lib/import.js'),
     contents: new Buffer('fake2')
   });
-  var unixPath2 = Plugin.unix(fake2.path);
+  var unixPath2 = unix(fake2.path);
 
   var plugin = Plugin([fake1, fake2]);
   var id1 = plugin.resolveId(unixPath1);
@@ -48,9 +48,9 @@ test('Accept array as parameters, resolve ids, load contents and resolve relativ
   t.true(plugin.load(id2) === fake2.contents.toString());
 
 
-  var relativeId = plugin.resolveId(Plugin.unix(fake2.relative), id1);
+  var relativeId = plugin.resolveId('./'+unix(fake2.relative), id1);
 
-  t.true(relativeId === Plugin.unix(fake2.path));
+  t.true(relativeId === unix(fake2.path));
   t.true(plugin.load(relativeId) === fake2.contents.toString());
 
 
@@ -69,9 +69,9 @@ test('Should import from non-vinyl file', t => {
 
   var filePath = path.resolve('src/main.js');
 
-  var id = plugin.resolveId(fake.relative, filePath);
+  var id = plugin.resolveId('./'+fake.relative, filePath);
 
-  t.true(id === Plugin.unix(fake.path));
+  t.true(id === unix(fake.path));
 
 });
 
@@ -91,7 +91,12 @@ test('Should not resolve id and not load on wrong import', t => {
 
   var id = plugin.resolveId(wrongId, filePath);
 
-  t.false(id === Plugin.unix(fake.path));
-  t.true(null === plugin.load(wrongId));
+  t.false(id === unix(fake.path));
+  t.true(null == plugin.load(wrongId));
 
 });
+
+
+function unix(value, sep) {
+  return value.split(sep || path.sep).join('/');
+}


### PR DESCRIPTION
There's a lot of aggravating stuff to take into account when making a hypothetical filesystem to feed to Rollup. That work only has to be done once if this plugin piggybacks on my plugin, [rollup-plugin-hypothetical](https://github.com/Permutatrix/rollup-plugin-hypothetical).

[I adapted a subset of rollup-plugin-hypothetical's tests to function as tests for rollup-plugin-vinyl and uploaded them as a Gist.](https://gist.github.com/Permutatrix/922cc4a0bf1ca5c40a1e0adcc183131e) Tests 3, 5, 7, 8, 10, 11, and 12 all fail with the current version of rollup-plugin-vinyl, but every test passes with this pull request. I didn't include the new tests in the PR, but you can add them if you like. They are MIT-licensed, after all.

You may want to expose rollup-plugin-hypothetical's options&mdash;`allowRealFiles`, `allowExternalModules`, and `leaveIdsAlone`.
